### PR TITLE
feat: move Profile & Settings to account dropdown menu in sidebar

### DIFF
--- a/apps/e2e/tests/dashboard.spec.ts
+++ b/apps/e2e/tests/dashboard.spec.ts
@@ -196,4 +196,71 @@ test.describe('Dashboard', () => {
       sidebar.getByRole('button', { name: 'Manage Rewards' }),
     ).toBeVisible();
   });
+
+  // --- Account dropdown tests (TDD: these should FAIL before sidebar refactor) ---
+
+  test('sidebar does NOT show Profile as a top-level nav item', async ({ page, isMobile }) => {
+    test.skip(isMobile, 'Sidebar navigation is desktop-only (hidden md:flex)');
+
+    const admin = await setupAdmin(page, 'dash.no-profile-nav');
+    await goToDashboard(page, admin.email, admin.password);
+
+    // Profile should NOT be a direct nav button in the sidebar main nav
+    const sidebar = page.locator('aside');
+    await expect(sidebar.getByRole('button', { name: 'Profile', exact: true })).not.toBeVisible();
+  });
+
+  test('sidebar does NOT show Settings as a top-level nav item', async ({ page, isMobile }) => {
+    test.skip(isMobile, 'Sidebar navigation is desktop-only (hidden md:flex)');
+
+    const admin = await setupAdmin(page, 'dash.no-settings-nav');
+    await goToDashboard(page, admin.email, admin.password);
+
+    // Settings should NOT be a direct nav button in the sidebar main nav
+    const sidebar = page.locator('aside');
+    await expect(sidebar.getByRole('button', { name: 'Settings', exact: true })).not.toBeVisible();
+  });
+
+  test('clicking account card in sidebar opens dropdown with Profile and Settings', async ({ page, isMobile }) => {
+    test.skip(isMobile, 'Sidebar navigation is desktop-only (hidden md:flex)');
+
+    const admin = await setupAdmin(page, 'dash.account-dropdown');
+    await goToDashboard(page, admin.email, admin.password);
+
+    const sidebar = page.locator('aside');
+    // Click the account card at the bottom of sidebar (button wrapping avatar+name)
+    await sidebar.getByTestId('account-menu-trigger').click();
+
+    // Dropdown should appear with Profile and Settings menu items
+    await expect(page.getByTestId('account-menu-profile')).toBeVisible();
+    await expect(page.getByTestId('account-menu-settings')).toBeVisible();
+  });
+
+  test('clicking Profile in account dropdown navigates to /profile', async ({ page, isMobile }) => {
+    test.skip(isMobile, 'Sidebar navigation is desktop-only (hidden md:flex)');
+
+    const admin = await setupAdmin(page, 'dash.dropdown-profile-nav');
+    await goToDashboard(page, admin.email, admin.password);
+
+    const sidebar = page.locator('aside');
+    await sidebar.getByTestId('account-menu-trigger').click();
+    await page.getByTestId('account-menu-profile').click();
+
+    await page.waitForURL('/profile');
+    await expect(page).toHaveURL('/profile');
+  });
+
+  test('clicking Settings in account dropdown navigates to /settings', async ({ page, isMobile }) => {
+    test.skip(isMobile, 'Sidebar navigation is desktop-only (hidden md:flex)');
+
+    const admin = await setupAdmin(page, 'dash.dropdown-settings-nav');
+    await goToDashboard(page, admin.email, admin.password);
+
+    const sidebar = page.locator('aside');
+    await sidebar.getByTestId('account-menu-trigger').click();
+    await page.getByTestId('account-menu-settings').click();
+
+    await page.waitForURL('/settings');
+    await expect(page).toHaveURL('/settings');
+  });
 });

--- a/apps/web/src/pages/dashboard/components/Sidebar.tsx
+++ b/apps/web/src/pages/dashboard/components/Sidebar.tsx
@@ -1,9 +1,9 @@
+import { useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 import {
   LayoutDashboard,
   Gift,
   Trophy,
-  User,
   Settings,
   ShieldCheck,
   Star,
@@ -11,8 +11,12 @@ import {
   BarChart3,
   Users,
   Tags,
+  User,
+  LogOut,
+  ChevronUp,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { useAuthStore } from '@/stores/auth-store';
 
 interface SidebarProps {
   onGiveKudos: () => void;
@@ -24,8 +28,6 @@ const mainNavItems = [
   { label: 'Dashboard', icon: LayoutDashboard, path: '/dashboard' },
   { label: 'Rewards', icon: Gift, path: '/rewards' },
   { label: 'Leaderboard', icon: Trophy, path: '/leaderboard' },
-  { label: 'Profile', icon: User, path: '/profile' },
-  { label: 'Settings', icon: Settings, path: '/settings' },
 ];
 
 const adminNavItems = [
@@ -47,6 +49,31 @@ export default function Sidebar({ onGiveKudos, user, orgName }: SidebarProps) {
   const location = useLocation();
   const navigate = useNavigate();
   const canSeeAdmin = user?.role === 'admin' || user?.role === 'owner';
+  const logout = useAuthStore((s) => s.logout);
+
+  const [menuOpen, setMenuOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  const handleSignOut = async () => {
+    setMenuOpen(false);
+    await logout();
+    navigate('/');
+  };
+
+  const accountMenuItems = [
+    {
+      label: 'My Profile',
+      icon: User,
+      path: '/profile',
+      testId: 'account-menu-profile',
+    },
+    {
+      label: 'Settings',
+      icon: Settings,
+      path: '/settings',
+      testId: 'account-menu-settings',
+    },
+  ];
 
   return (
     <aside className="hidden w-[244px] flex-shrink-0 flex-col border-r border-slate-200 bg-white md:flex">
@@ -137,16 +164,69 @@ export default function Sidebar({ onGiveKudos, user, orgName }: SidebarProps) {
         </button>
       </div>
 
-      <div className="border-t border-slate-100 bg-slate-50/70 px-4 py-3">
-        <div className="flex items-center gap-3">
+      {/* Account card with dropdown */}
+      <div className="relative border-t border-slate-100">
+        {/* Dropdown menu — renders above the trigger */}
+        {menuOpen && (
+          <>
+            {/* Backdrop to close on outside click */}
+            <div
+              className="fixed inset-0 z-10"
+              onClick={() => setMenuOpen(false)}
+              aria-hidden="true"
+            />
+            <div className="absolute bottom-full left-0 right-0 z-20 mb-1 mx-2 rounded-xl border border-slate-200 bg-white shadow-lg overflow-hidden">
+              {accountMenuItems.map(({ label, icon: Icon, path, testId }) => (
+                <button
+                  key={label}
+                  type="button"
+                  data-testid={testId}
+                  onClick={() => {
+                    setMenuOpen(false);
+                    navigate(path);
+                  }}
+                  className="flex w-full items-center gap-3 px-4 py-3 text-sm text-slate-700 hover:bg-violet-50 hover:text-violet-700 transition"
+                >
+                  <Icon className="h-4 w-4" />
+                  {label}
+                </button>
+              ))}
+              <div className="mx-3 border-t border-slate-100" />
+              <button
+                type="button"
+                data-testid="account-menu-signout"
+                onClick={() => void handleSignOut()}
+                className="flex w-full items-center gap-3 px-4 py-3 text-sm text-red-500 hover:bg-red-50 transition"
+              >
+                <LogOut className="h-4 w-4" />
+                Sign Out
+              </button>
+            </div>
+          </>
+        )}
+
+        {/* Trigger button */}
+        <button
+          ref={triggerRef}
+          type="button"
+          data-testid="account-menu-trigger"
+          onClick={() => setMenuOpen((prev) => !prev)}
+          className="flex w-full items-center gap-3 bg-slate-50/70 px-4 py-3 hover:bg-slate-100 transition group"
+        >
           <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full bg-violet-100 text-xs font-bold text-violet-700">
             {user ? getInitials(user.fullName) : '?'}
           </div>
-          <div className="min-w-0 flex-1">
+          <div className="min-w-0 flex-1 text-left">
             <p className="truncate text-sm font-semibold text-slate-800">{user?.fullName ?? ''}</p>
             <p className="truncate text-xs text-slate-400">{user?.email ?? ''}</p>
           </div>
-        </div>
+          <ChevronUp
+            className={cn(
+              'h-4 w-4 flex-shrink-0 text-slate-400 transition-transform duration-200',
+              menuOpen ? 'rotate-180' : 'rotate-0',
+            )}
+          />
+        </button>
       </div>
     </aside>
   );


### PR DESCRIPTION
## Summary

Removes **Profile** and **Settings** from the sidebar's main navigation and moves them into an account dropdown menu triggered by clicking the user card (avatar + name) at the bottom of the sidebar.

## UI/UX Rationale

Profile and Settings are account-level actions, not content destinations. Modern apps (Notion, Linear, Slack) consistently keep these in a collapsed account menu rather than the primary navigation, reducing cognitive load and keeping the sidebar focused.

## Changes

- **`Sidebar.tsx`**: Removed Profile/Settings from `mainNavItems`; converted bottom user card into a clickable button that opens a dropdown with:
  - �� My Profile → `/profile`
  - ⚙️ Settings → `/settings`
  - 🔐 Sign Out → clears session, redirects to `/`
  - ChevronUp icon animates open/closed; click-outside closes the dropdown

## TDD

- Wrote 5 new failing E2E tests in `dashboard.spec.ts` **before** implementing changes ✅
- Rebuilt Docker after code changes ✅
- **18/18 dashboard E2E tests pass** ✅