### PR TITLE
fix: make Rewards and Leaderboard pages full-width on wide screens

### DIFF
--- a/apps/web/src/pages/leaderboard/Leaderboard.tsx
+++ b/apps/web/src/pages/leaderboard/Leaderboard.tsx
@@ -124,7 +124,7 @@ export default function Leaderboard() {
 
   return (
     <DashboardLayout>
-      <div className="mx-auto max-w-4xl space-y-6">
+      <div className="space-y-6">
         {/* Hero Header */}
         <section className="relative overflow-hidden rounded-3xl bg-gradient-to-br from-violet-600 to-indigo-600 p-8 text-white shadow-xl">
           <div className="absolute right-0 top-0 -translate-y-1/4 translate-x-1/4 h-64 w-64 rounded-full bg-white/5 blur-3xl" />

--- a/apps/web/src/pages/rewards/Rewards.tsx
+++ b/apps/web/src/pages/rewards/Rewards.tsx
@@ -75,7 +75,7 @@ export default function Rewards() {
 
   return (
     <DashboardLayout>
-      <div className="mx-auto max-w-6xl space-y-6">
+      <div className="space-y-6">
         <section>
           <h1 className="text-4xl font-extrabold tracking-tight text-slate-900">
             Rewards Catalog 🎁


### PR DESCRIPTION
Remove `max-width` constraints (`max-w-6xl` on Rewards, `max-w-4xl` on Leaderboard) so both pages fill the available content area consistently with the Dashboard.

Closes #12